### PR TITLE
Improve mac generation for multiple ifaces - go by radio id

### DIFF
--- a/docs/features/private-wlan.rst
+++ b/docs/features/private-wlan.rst
@@ -27,7 +27,7 @@ You may also enable a private WLAN using the command line::
   uci set wireless.wan_radio$RID.ssid="$SSID"
   uci set wireless.wan_radio$RID.key="$KEY"
   uci set wireless.wan_radio$RID.disabled=0
-  uci set wireless.wan_radio$RID.macaddr=$(lua -e "print(require('gluon.util').generate_mac(3+4*$RID))")
+  uci set wireless.wan_radio$RID.macaddr=$(lua -e "print(require('gluon.util').generate_mac($RID, 'wan_radio')")
   uci commit
   wifi
 

--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
@@ -37,7 +37,7 @@ local function configure_ap(radio, index, config, radio_name)
 
 	uci:delete('wireless', name)
 
-	local macaddr = wireless.get_wlan_mac(uci, radio, index, 1)
+	local macaddr = wireless.get_wlan_mac(uci, radio, index, 'client')
 
 	if not ap.ssid() or not macaddr then
 		return
@@ -70,7 +70,7 @@ local function configure_owe(radio, index, config, radio_name)
 		return
 	end
 
-	local macaddr = wireless.get_wlan_mac(uci, radio, index, 3)
+	local macaddr = wireless.get_wlan_mac(uci, radio, index, 'mesh')
 
 	if not ap.owe_ssid() or not macaddr then
 		return

--- a/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
+++ b/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
@@ -7,7 +7,7 @@
 init_proto "$@"
 
 proto_gluon_wired_init_config() {
-	proto_config_add_int index
+	proto_config_add_string use
 	proto_config_add_boolean vxlan
 	proto_config_add_string vxpeer6addr
 }
@@ -49,8 +49,8 @@ proto_gluon_wired_setup() {
 
 	local meshif="$config"
 
-	local index vxlan vxpeer6addr
-	json_get_vars index vxlan vxpeer6addr
+	local use vxlan vxpeer6addr
+	json_get_vars use vxlan vxpeer6addr
 
 	# default args
 	[ -z "$vxlan" ] && vxlan=1
@@ -64,7 +64,7 @@ proto_gluon_wired_setup() {
 
 		json_init
 		json_add_string name "$meshif"
-		[ -n "$index" ] && json_add_string macaddr "$(lua -e "print(require('gluon.util').generate_mac($index))")"
+		[ -n "$use" ] && json_add_string macaddr "$(lua -e "print(require('gluon.util').generate_mac(0, '$use'))")"
 		json_add_string proto 'vxlan6'
 		json_add_string tunlink "$config"
 		# ip6addr (the lower interface ip6) is used by the vxlan.sh proto

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -124,7 +124,7 @@ local function configure_mesh(config, radio, index, suffix, disabled)
 		return
 	end
 
-	local macaddr = wireless.get_wlan_mac(uci, radio, index, 2)
+	local macaddr = wireless.get_wlan_mac(uci, radio, index, 'client')
 	if not macaddr then
 		return
 	end
@@ -157,7 +157,7 @@ local function fixup_wan(radio, index)
 		return
 	end
 
-	local macaddr = wireless.get_wlan_mac(uci, radio, index, 4)
+	local macaddr = wireless.get_wlan_mac(uci, radio, index, 'wan_radio')
 	if not macaddr then
 		return
 	end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/210-interface-mesh
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/210-interface-mesh
@@ -21,7 +21,7 @@ if #mesh_interfaces_uplink > 0 then
 	uci:section('network', 'interface', 'mesh_uplink', {
 		ifname = 'br-wan',
 		proto = 'gluon_wired',
-		index = 0,
+		use = 'wan',
 		vxlan = site.mesh.vxlan(true),
 	})
 end
@@ -48,7 +48,7 @@ if #mesh_interfaces_other > 0 then
 		type = iftype,
 		igmp_snooping = false,
 		proto = 'gluon_wired',
-		index = 4,
+		use = 'mesh_other',
 		vxlan = site.mesh.vxlan(true),
 	})
 end

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -175,7 +175,17 @@ end
 
 -- Generates a (hopefully) unique MAC address
 -- The parameter defines the ID to add to the MAC address
---
+
+local interface_ids = {
+	client = 0,
+	mesh = 1,
+	owe = 2,
+	wan_radio = 3,
+	primary = 3,
+	mesh_other = 4,
+	mesh_vpn = 7,
+}
+
 -- IDs defined so far:
 -- 0: client0; WAN
 -- 1: mesh0
@@ -189,7 +199,8 @@ end
 -- 9: mesh2
 -- A: owe2
 -- B: wan_radio2
-function M.generate_mac(i)
+function M.generate_mac(id, use)
+	-- when use is set, the id should be radio id, but can be plain id for backwards compatibility
 	local hashed = string.sub(hash.md5(sysconfig.primary_mac), 0, 12)
 	local m1, m2, m3, m4, m5, m6 = string.match(hashed, '(%x%x)(%x%x)(%x%x)(%x%x)(%x%x)(%x%x)')
 
@@ -203,10 +214,16 @@ function M.generate_mac(i)
 	-- vary on a single hardware interface, since some chips are using
 	-- a hardware MAC filter. (e.g 'rt305x')
 
+	local i
+
+	if use == nil then
+		i = id
+	else
+		i = 4*id + interface_ids[use]
+	end
+
 	m6 = bit.band(m6, 0xF8) -- zero the last three bits (space needed for counting)
 	m6 = bit.band(m6 + i, 0xFF) -- add virtual interface id
-
-
 	return string.format('%02x:%s:%s:%s:%s:%02x', m1, m2, m3, m4, m5, m6)
 end
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -49,13 +49,14 @@ function M.supports_channel(radio, channel)
 	return false
 end
 
-function M.get_wlan_mac(_, radio, index, vif)
-	local addr = get_wlan_mac_from_driver(radio, vif)
+function M.get_wlan_mac(_, radio, index, use)
+	local vif = util.interface_ids[use]
+	local addr = get_wlan_mac_from_driver(radio, vif+1)
 	if addr then
 		return addr
 	end
 
-	return util.generate_mac(4*(index-1) + (vif-1))
+	return util.generate_mac(index-1, use)
 end
 
 -- Iterate over all radios defined in UCI calling

--- a/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
+++ b/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
@@ -72,7 +72,7 @@ proto_gluon_bat0_setup() {
 
 
 	local primary0_mac
-	primary0_mac="$(lua -e 'print(require("gluon.util").generate_mac(3))')"
+	primary0_mac="$(lua -e 'print(require("gluon.util").generate_mac(0, "primary"))')"
 
 	ip link add primary0 type dummy
 	echo 1 > /proc/sys/net/ipv6/conf/primary0/disable_ipv6

--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/330-gluon-mesh-batman-adv-mac-addresses
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/330-gluon-mesh-batman-adv-mac-addresses
@@ -10,6 +10,6 @@ if not site.mesh.vxlan(true) then
 	uci:set('network', 'wan', 'macaddr', util.generate_mac(0))
 end
 if uci:get('network', 'mesh_other') then
-	uci:set('network', 'mesh_other', 'macaddr', util.generate_mac(4))
+	uci:set('network', 'mesh_other', 'macaddr', util.generate_mac(0, "mesh_other"))
 end
 uci:save('network')

--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
@@ -12,7 +12,7 @@ uci:section('network', 'interface', 'mesh_vpn', {
 	ifname = vpn_core.get_interface(),
 	proto = 'gluon_mesh',
 	fixed_mtu = true,
-	macaddr = util.generate_mac(7),
+	macaddr = util.generate_mac(0, 'mesh_vpn'),
 	mtu = active_vpn.mtu(),
 })
 

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
@@ -71,7 +71,7 @@ function f:write()
 		local name   = "wan_" .. radio_name
 
 		if enabled.data then
-			local macaddr = wireless.get_wlan_mac(uci, radio, index, 4)
+			local macaddr = wireless.get_wlan_mac(uci, radio, index, 'wan_radio')
 
 			uci:section('wireless', 'wifi-iface', name, {
 				device     = radio_name,

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -95,7 +95,7 @@ uci:foreach('wireless', 'wifi-device', function(config)
 
 	vif_option('client', {'client', 'owe'}, translate('Enable client network (access point)'))
 
-    -- only show mesh iface setting on radios which support the configured mesh channel
+	-- only show mesh iface setting on radios which support the configured mesh channel
 	if wireless.supports_channel(config, tonumber(config.channel)) then
 		local mesh_vif = vif_option('mesh', {'mesh'}, translate("Enable mesh network (802.11s)"))
 


### PR DESCRIPTION
this adds the triband mac generation as discussed in
https://github.com/freifunk-gluon/gluon/pull/3357#discussion_r2023746381

Maybe this is about what was expected then, but this probably should reside in a separate PR..