### PR TITLE
mediatek-filogic: add gluon support for zyxel-ex5601-t0-ubootmod

### DIFF
--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -135,3 +135,12 @@ device('xiaomi-mi-router-ax3000t-openwrt-u-boot-layout', 'xiaomi_mi-router-ax300
 -- Zyxel
 
 device('zyxel-nwa50ax-pro', 'zyxel_nwa50ax-pro')
+
+device('zyxel-ex5601-t0-ubootmod', 'zyxel_ex5601-t0-ubootmod', {
+	factory = false,
+	sysupgrade_ext = '.itb',
+	extra_images = {
+		{ '-preloader', '-preloader', '.bin' },
+		{ '-bl31-uboot', '-bl31-uboot', '.fip' },
+	},
+})


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [~] Web interface
  - [x] TFTP (requires some steps in the web ui to obtain root access)
  - [~] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [ ] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs (broken right now)
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present)  -- LAN LED is constantly active if no LAN port has a link, WAN LED works as expected
    - [x] Should show link state and activity
- Outdoor devices only:
  - [~] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [~] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [~] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [ ] Added Device to `docs/user/supported_devices.rst`
